### PR TITLE
fix misplaced parens in HpRegenPerTick/MpRegenPerTick formulas

### DIFF
--- a/src/XSD/ServerConfig.xsd
+++ b/src/XSD/ServerConfig.xsd
@@ -246,8 +246,8 @@
       <xs:element name="MpGainPerLevel" type="xs:string" default="((SOURCEWIS/(SOURCELEVEL + 1)*50)*(RANDDOUBLE*0.30+0.85))+25"/>
       <xs:element name="AllowedCarryWeight" type="xs:string" default="SOURCESTR+(SOURCELEVEL/4) + 48"/>
       <xs:element name="AllowedEquipmentWeight" type="xs:string" default="(SOURCESTR+(SOURCELEVEL/4) + 48)/2"/>
-      <xs:element name="MpRegenPerTick" type="xs:string" default="Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01, SOURCEMAXIMUMMP * 0.20))"/>
-      <xs:element name="HpRegenPerTick" type="xs:string" default="Min(SOURCEMAXIMUMHP * (0.1 + Max(SOURCECON, SOURCECON - SOURCELEVEL) * 0.01, SOURCEMAXIMUMHP * 0.20))"/>                  
+      <xs:element name="MpRegenPerTick" type="xs:string" default="Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01), SOURCEMAXIMUMMP * 0.20)"/>
+      <xs:element name="HpRegenPerTick" type="xs:string" default="Min(SOURCEMAXIMUMHP * (0.1 + Max(SOURCECON, SOURCECON - SOURCELEVEL) * 0.01), SOURCEMAXIMUMHP * 0.20)"/>                  
       <xs:element name="AcDamageMitigation" type="xs:string" default=""/>
       <xs:element name="AcMagicDamageMitigation" type="xs:string" default=""/>
       <xs:element name="MonsterHpGainPerLevel" type="xs:string" default="((SOURCECON/(SOURCELEVEL + 1)*50)*(RANDDOUBLE*0.30+0.85))+25"/>


### PR DESCRIPTION
## Summary
- `Min(...)` in both regen formulas was receiving a single argument because the closing paren landed at the end of the expression instead of after the inner multiplication
- The cap term (`SOURCEMAXIMUMHP/MP * 0.20`) was being swallowed into the first arg, so `Min()` effectively did nothing — there was no upper bound on regen
- Two-line edit in `src/XSD/ServerConfig.xsd` (lines 249-250)

### Before
```
Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01, SOURCEMAXIMUMMP * 0.20))
```
One arg to `Min`. The `,` lives inside the inner `(...)` — gibberish.

### After
```
Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01), SOURCEMAXIMUMMP * 0.20)
```
Two args: the regen value, capped at 20% of max.

## Test plan
- [ ] Sanity check the formula parses in the server's expression evaluator
- [ ] Confirm regen behavior matches the cap (regen never exceeds 20% of max HP/MP per tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)