### PR TITLE
add DynamicLighting attribute to Map

### DIFF
--- a/src/Objects/Map.cs
+++ b/src/Objects/Map.cs
@@ -42,6 +42,7 @@ public partial class Map : HybrasylEntity<Map>
     private byte _y;
     private bool _isEnabled;
     private bool _allowCasting;
+    private bool _dynamicLighting;
     #endregion
     
     public Map()
@@ -54,6 +55,7 @@ public partial class Map : HybrasylEntity<Map>
         _music = ((byte)(0));
         _isEnabled = true;
         _allowCasting = true;
+        _dynamicLighting = false;
     }
     
     public string Name
@@ -234,6 +236,20 @@ public partial class Map : HybrasylEntity<Map>
         set
         {
             _allowCasting = value;
+        }
+    }
+
+    [XmlAttribute]
+    [DefaultValue(false)]
+    public bool DynamicLighting
+    {
+        get
+        {
+            return _dynamicLighting;
+        }
+        set
+        {
+            _dynamicLighting = value;
         }
     }
 }

--- a/src/XSD/Map.xsd
+++ b/src/XSD/Map.xsd
@@ -127,6 +127,7 @@
     <xs:attribute name="Y" type="xs:unsignedByte" use="required" />
     <xs:attribute name="IsEnabled" type="xs:boolean" use="optional" default="true" />
     <xs:attribute name="AllowCasting" type="xs:boolean" use="optional" default="true" />
+    <xs:attribute name="DynamicLighting" type="xs:boolean" use="optional" default="false" />
   </xs:complexType>
 
   <xs:complexType name="MapNpc">


### PR DESCRIPTION
## Summary
- Add optional `DynamicLighting` boolean attribute to the `Map` element, defaulting to `false`
- Mirrors the existing `IsEnabled` / `AllowCasting` attributes (`[XmlAttribute]` + `[DefaultValue(false)]`)
- One property added in `src/Objects/Map.cs`, one matching attribute added in `src/XSD/Map.xsd`

## Test plan
- [ ] `dotnet build` succeeds
- [ ] Existing `LoadDataContainsNoLoadErrors` Map check still passes (catches any XSD/serialization regression)
- [ ] Downstream consumer (server-side lighting logic) can read the flag once wired up

🤖 Generated with [Claude Code](https://claude.com/claude-code)