### PR TITLE
fix: correct misplaced parens in generated regen formula defaults (regen was silently 0)

### DIFF
--- a/src/Hybrasyl.Xml.csproj
+++ b/src/Hybrasyl.Xml.csproj
@@ -6,8 +6,8 @@
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
     <RootNamespace>Hybrasyl.Xml</RootNamespace>
-    <PackageVersion>0.9.6</PackageVersion>
-    <Version>0.9.6</Version>
+    <PackageVersion>0.9.7</PackageVersion>
+    <Version>0.9.7</Version>
     <BuildDocFx Condition="'$(Configuration)'=='Debug'">false</BuildDocFx>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Authors>ERISCO LLC</Authors>

--- a/src/Objects/ServerFormulas.cs
+++ b/src/Objects/ServerFormulas.cs
@@ -47,10 +47,8 @@ public partial class ServerFormulas : HybrasylEntity<ServerFormulas>
         _mpGainPerLevel = "((SOURCEWIS/(SOURCELEVEL + 1)*50)*(RANDDOUBLE*0.30+0.85))+25";
         _allowedCarryWeight = "SOURCESTR+(SOURCELEVEL/4) + 48";
         _allowedEquipmentWeight = "(SOURCESTR+(SOURCELEVEL/4) + 48)/2";
-        _mpRegenPerTick = "Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01, SOUR" +
-            "CEMAXIMUMMP * 0.20))";
-        _hpRegenPerTick = "Min(SOURCEMAXIMUMHP * (0.1 + Max(SOURCECON, SOURCECON - SOURCELEVEL) * 0.01, SOUR" +
-            "CEMAXIMUMHP * 0.20))";
+        _mpRegenPerTick = "Min(SOURCEMAXIMUMMP * (0.1 + Max(SOURCEWIS, SOURCEWIS - SOURCELEVEL) * 0.01), SOURCEMAXIMUMMP * 0.20)";
+        _hpRegenPerTick = "Min(SOURCEMAXIMUMHP * (0.1 + Max(SOURCECON, SOURCECON - SOURCELEVEL) * 0.01), SOURCEMAXIMUMHP * 0.20)";
         _acDamageMitigation = "";
         _acMagicDamageMitigation = "";
         _monsterHpGainPerLevel = "((SOURCECON/(SOURCELEVEL + 1)*50)*(RANDDOUBLE*0.30+0.85))+25";


### PR DESCRIPTION
## Problem

HP/MP regen has been silently zero for any world whose config omits a `Formulas`
section — which includes ceridwen, whose `xml/serverconfigs/config.xml` contains no
`Formula` elements at all, so the hardcoded C# defaults are in use.

`src/Objects/ServerFormulas.cs` is `<auto-generated>` by Xsd2Code++ and had drifted
from the XSD:

```
Min( MAXHP * (0.1 + Max(CON, CON-LVL) * 0.01, MAXHP * 0.20) )
             ^ this paren should close after * 0.01
```

`Min()` therefore received a **single** argument. NCalc throws
`NCalcEvaluationException: Min() takes exactly 2 arguments`; Hybrasyl's
`FormulaParser.Eval` catches all exceptions and returns `0.0`; `World.cs` casts that
to `(uint)` — so regen is 0.

## How the drift happened

- `a5759ab` fixed the parens in **both** the XSD and `ServerFormulas.cs`, but to the
  wrong parenthesization (`Min` still got one argument).
- `5a1a080` ("fix misplaced parens in HpRegenPerTick/MpRegenPerTick formulas")
  corrected the **XSD only** — `ServerFormulas.cs` was never regenerated.

So the XSD has been right since April and the generated C# has been wrong since.

## Fix

Regenerate-equivalent hand-patch of the two literals to match the XSD. The XSD is
unchanged and already correct, so a future Xsd2Code++ run will now agree with this
file.

## Verification

- Both C# literals confirmed **byte-identical** to their XSD `default=` attributes by
  extracting and comparing them programmatically (not by eye — an eyeballed paren in a
  wrapped string literal is how this was introduced).
- Defaults extracted from the patched file and evaluated through `NCalcSync 6.3.1`
  using `FormulaParser.Eval`'s semantics, for a level-10 character with CON/WIS 30 and
  1000 max HP/MP:

```
[PASS] _mpRegenPerTick          = 200      (was: throws -> 0)
[PASS] _hpRegenPerTick          = 200      (was: throws -> 0)
[PASS] _xpToNextLevel           = 250000
[PASS] _hpGainPerLevel          = 161.36
[PASS] _allowedCarryWeight      = 100.5
[PASS] _allowedEquipmentWeight  = 50.25
```

- `dotnet build` across all four TFMs: `0 Error(s)`.

## Behaviour change — please read

This restores a cap that has not been functioning. With correct parens the `Min` binds
at `CON >= 10`, so HP regen becomes a flat **20% of max HP per tick** for essentially
any character. That is exactly what the XSD specifies, but since regen has effectively
been 0, the swing is large and worth a balance look before this reaches players.

## Release note

Package version bumped `0.9.6` → `0.9.7`. Publishing is triggered by pushing a `v*`
tag (or manual `workflow_dispatch`), **not** by merging this PR — the package won't
exist on nuget.org until tagged. hybrasyl-server pins `Hybrasyl.Xml` at `0.9.6` via
`PackageReference`, so it will not pick this up until the tag is pushed and the
reference bumped (or it is built with `UseLocalXml=true`).

## Context

Found while investigating a claim that NCalc truncates integer division. That claim was
measured false — `25 / 100` → `0.25 [Double]` on 6.3.1, 5.8.0, and master — and the
regen symptom traced entirely to these parens. Full write-up in comhaigne
(`docs/plans/hybrasyl-server/ncalc-integer-division.md`).

Generated with Imbas <imbas@eris.co>
